### PR TITLE
use python logging rather than inkex logging (more flexible/powerful)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,24 @@ The three library files are:
 * ebb_serial.py - Routines for communicating with the EiBotBoard by USB serial (PySerial 2.7 + required).
 * ebb_motion.py - Common commands for interacting with the robot
 * plot_utils.py - Additional helper functions for managing the plot.
+
+## Logging
+
+This library uses the standard python logging module. Suggested configurations follow.
+
+For manual command of AxiDraw, print info, warnings, and errors to stdout:
+
+```
+import logging
+
+logging.basicConfig(level=logging.INFO, format='%(message)s')
+```
+
+For running as an inkscape extension, print errors to inkscape's extension errors log:
+```
+import logging
+
+logging.basicConfig(level=logging.ERR,
+        format='%(message)s'),
+        filename = "~/.config/inkscape/extension-errors.log")
+```


### PR DESCRIPTION
Raising exceptions changes the behavior of `query` and `command`, which you quite rightly pointed out means carefully making changes to many other pieces of code. So I tried using logging and it was absurdly easy. Logging is turned off by default, and whatever application consumes ebb_serial can decide if/when/where to print logging messages. (See README.md)