### PR TITLE
Log serial.SerialException when unable to testPort(..) successfully

### DIFF
--- a/plotink/ebb_serial.py
+++ b/plotink/ebb_serial.py
@@ -294,8 +294,9 @@ def testPort(port_name):
             if str_version and str_version.startswith("EBB".encode('ascii')):
                 return serial_port
             serial_port.close()
-        except serial.SerialException:
-            pass
+        except serial.SerialException as err:
+            logger.error("Error testing serial port `{}` connection".format(port_name))
+            logger.info("Error context:", exc_info=err)
         return None
 
 


### PR DESCRIPTION
Spent a few hours this morning chasing down why I couldn't connect to the AxiDraw V3 -- turns out it was a permission error related to the USB socket my AxiDraw was connected to. This info is captured in the `serial.SerialException`, but that information is unfortunately suppressed by the `pass` statement I've replaced here.