### PR TITLE
Add "verbose" argument to most functions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='plotink',
-    version='1.6.2',
+    version='1.7.0',
     python_requires='>=3.6.0',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Backwards compatible; Defaults to verbose=True, giving same behavior. 
Version bump to 1.7.0