### PR TITLE
Remove test modules from sdist, wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         "Intended Audience :: Developers",
     ],
 
-    packages=find_packages(exclude=['contrib', 'docs', 'tests']),
+    packages=find_packages(exclude=['contrib', 'docs', 'test', 'test.*']),
     install_requires=[
         'ink_extensions',
         'packaging>=21.0',


### PR DESCRIPTION
Just like in https://github.com/evil-mad/ink_extensions/pull/8, I think test modules shouldn’t be in the sdist and wheels.
