### PR TITLE
Optionally log and replay serial commands sent to EBB

### DIFF
--- a/plotink/ebb_replay_log.py
+++ b/plotink/ebb_replay_log.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+HELP = '''
+This simple script replays the commands logged by 
+the EggBot Inkscape extension.
+
+Usage: python3 ebb_replay_log.py <logfile> <serial port>
+'''
+
+from serial import Serial
+import sys
+
+if len(sys.argv) < 3:
+    print(HELP)
+    sys.exit(-1)
+
+filename = sys.argv[1]
+port = sys.argv[2]
+
+ser = Serial(port, 115200)
+commands = open(filename).readlines()
+
+for command in commands:
+    ser.write(command.encode('ascii'))
+    ret = ser.readline()
+    print(command, ret)

--- a/plotink/ebb_serial.py
+++ b/plotink/ebb_serial.py
@@ -46,6 +46,8 @@ from serial.tools.list_ports import comports \
 
 logger = logging.getLogger(__name__)
 
+command_log = None
+
 def version():
     '''Version number for this document'''
     return "0.19"   # Dated 2022-10-05
@@ -299,6 +301,21 @@ def testPort(port_name):
     return None
 
 
+def startLogging(logfile):
+    global command_log
+    if logfile and not command_log:
+        try:
+            command_log = open(logfile, 'wb')
+        except PermissionError:
+            command_log = None  # be explicit
+
+
+def stopLogging():
+    global command_log
+    if command_log:
+        command_log.close()
+
+
 def openPort():
     '''
     Find and open a port to a single attached EiBotBoard.
@@ -376,6 +393,8 @@ def command(port_name, cmd, verbose=True):
     '''General command to send a command to the EiBotBoard'''
     if port_name is not None and cmd is not None:
         try:
+            if command_log:
+                command_log.write(cmd.encode('ascii'))
             port_name.write(cmd.encode('ascii'))
             response = port_name.readline().decode('ascii')
             n_retry_count = 0


### PR DESCRIPTION
These commits enable ebb_serial.py to optionally log all commands sent to the EBB into a file.
A script `ebb_replay_log.py` allows for replaying the list of commands to a serial port.

Together with changes to the EggBot Inkscape extension, this makes it possible to create a design in Inkscape, save the plotting commands into a command log, and then plot the design again without requiring Inkscape.
This is useful for automated / repeated plotting of the same design.