### PR TITLE
Make `ebb3_serial` more robust

### DIFF
--- a/plotink/ebb3_serial.py
+++ b/plotink/ebb3_serial.py
@@ -227,7 +227,7 @@ class EBB3:
 
         verified = False
         try:
-            self.port = serial.Serial(self.port_name, timeout=1.0)  # 1 second timeout!
+            self.port = serial.Serial(self.port_name, timeout=.1)  # 1 second timeout!
             self.port.reset_input_buffer() # Requires pyserial 3+.
 
             self.port.write('v\r'.encode('ascii'))    # Request version string.

--- a/plotink/ebb3_serial.py
+++ b/plotink/ebb3_serial.py
@@ -58,7 +58,9 @@ class EBB3:
         self.name = None            # EBB "nickname," if known
         self.err = None             # None, or a string giving first fatal error message.
         self.caller = None          # None, or a string indicating which program opened the port
-
+        self.retry_count = 0        # A counter keeping track of how many times a command or
+                                    # query had to be retried due to timing out or an unexpected
+                                    # response from the EBB
 
     def find_first(self):
         '''
@@ -412,6 +414,7 @@ class EBB3:
         # if the response is unexpected or empty, recursively try again according to `num_tries`
         if not response.startswith(request_name):
             if num_tries > 1:
+                self.retry_count += 1
                 self._send_request(type, request, request_name, num_tries - 1)
             else: # base case; num_tries == 1 (or less but that would be silly)
                 if response:

--- a/plotink/ebb3_serial.py
+++ b/plotink/ebb3_serial.py
@@ -227,7 +227,7 @@ class EBB3:
 
         verified = False
         try:
-            self.port = serial.Serial(self.port_name, timeout=.00001)  # 1 second timeout!
+            self.port = serial.Serial(self.port_name, timeout=1.0)  # 1 second timeout!
             self.port.reset_input_buffer() # Requires pyserial 3+.
 
             self.port.write('v\r'.encode('ascii'))    # Request version string.
@@ -405,7 +405,12 @@ class EBB3:
       def response_incomplete(the_response):
             return len(the_response) == 0 or the_response[-1] != "\n"
 
+      old_timeout = self.port.timeout
+
       try:
+        # set read timeout to very small so we don't block on waiting for readline to finish
+        self.port.timeout = .00001
+
         # send the request
         self.port.write((request + '\r').encode('ascii'))
 
@@ -448,6 +453,8 @@ class EBB3:
             self.record_error('\nEBB Serial Error.' +\
                 f'    Command: {request}\n    Response: {response}')
             return None
+      finally:
+        self.port.timeout = old_timeout
 
 
         '''

--- a/plotink/ebb3_serial.py
+++ b/plotink/ebb3_serial.py
@@ -308,15 +308,9 @@ class EBB3:
         response = ''
         try:
             self.port.write((cmd + '\r').encode('ascii'))
-            response = self._readline_with_retries()
-            if not response.startswith(cmd_name):
-                if response:
-                    error_msg = '\nUnexpected response from EBB.' +\
-                       f'    Command: {cmd}\n    Response: {response}'
-                else:
-                    error_msg = f'EBB Serial Timeout after command: {cmd}'
-                self.record_error(error_msg)
-
+            response = self._get_and_eval_response('command', cmd, cmd_name)
+            if response is None:
+                return False
         except (serial.SerialException, IOError, RuntimeError, OSError):
             if cmd_name.lower() not in ["rb", "r", "bl"]: # Ignore err on these commands
                 error_msg = f'USB communication error after command: {cmd}'
@@ -353,14 +347,8 @@ class EBB3:
         response = ''
         try:
             self.port.write((qry + '\r').encode('ascii'))
-            response = self._readline_with_retries()
-            if not response.startswith(qry_name):
-                if response:
-                    error_msg = '\nUnexpected response from EBB.' +\
-                       f'    Query: {qry}\n    Response: {response}'
-                else:
-                    error_msg = f'EBB Serial Timeout after query: {qry}'
-                self.record_error(error_msg)
+            response = self._get_and_eval_response('query', qry, qry_name)
+            if response is None:
                 return None
         except (serial.SerialException, IOError, RuntimeError, OSError):
             if qry_name.lower() not in ["rb", "r", "bl"]: # Ignore err on these commands
@@ -391,15 +379,9 @@ class EBB3:
         response = ''
         try:
             self.port.write('QG\r'.encode('ascii'))
-            response = self._readline_with_retries()
-            if not response.startswith('QG'):
-                if response:
-                    error_msg = '\nUnexpected response from EBB.' +\
-                       f'    Response to QG query: {response}'
-                else:
-                    error_msg = 'EBB Serial Timeout while reading status byte.'
-                self.record_error(error_msg)
-
+            response = self._get_and_eval_response('query', 'QG', 'QG')
+            if response is None:
+                return None
         except (serial.SerialException, IOError, RuntimeError, OSError):
             error_msg = 'USB communication error after status byte query'
             self.record_error(error_msg)
@@ -413,13 +395,27 @@ class EBB3:
         except (TypeError, ValueError):
             return None
 
-    def _readline_with_retries(self):
+    def _get_and_eval_response(self, type, request, request_name):
+        '''
+        `request` is the previous command or query ent to the Ebb
+        `type` is 'command' or 'query'
+        return None if there's an error
+        '''
         response = ""
         n_retry_count = 0
         while len(response) == 0 and n_retry_count < self.readline_retry_max:
             # get new response to replace null response if necessary
             response = self.port.readline().decode('ascii').strip()
             n_retry_count += 1
+
+        if not response.startswith(request_name):
+            if response:
+                error_msg = '\nUnexpected response from EBB.' +\
+                   f'    Command: {request}\n    Response: {response}'
+            else:
+                error_msg = f'EBB Serial Timeout after {type}: {request}'
+            self.record_error(error_msg)
+            return None
         return response
 
     def _check_and_record_ebb_error(self, response, type, request):

--- a/plotink/ebb3_serial.py
+++ b/plotink/ebb3_serial.py
@@ -227,7 +227,7 @@ class EBB3:
 
         verified = False
         try:
-            self.port = serial.Serial(self.port_name, timeout=.05)  # 1 second timeout!
+            self.port = serial.Serial(self.port_name, timeout=.00001)  # 1 second timeout!
             self.port.reset_input_buffer() # Requires pyserial 3+.
 
             self.port.write('v\r'.encode('ascii'))    # Request version string.

--- a/plotink/ebb3_serial.py
+++ b/plotink/ebb3_serial.py
@@ -423,10 +423,18 @@ class EBB3:
         n_retry_count = 0
         # poll for response until we get any response and self.port indicates there is no more input, a maximum of self.readline_retry_max times  # TODO adjust/tune retries and timeout params
         while (len(responses) == 0 or self.port.in_waiting > 0) and n_retry_count < self.readline_retry_max:
-            next_line = self.port.readline()
-            if len(next_line) > 0:
-                responses.append(next_line)
             n_retry_count += 1
+            in_bytes = self.port.readline()
+            if len(in_bytes) == 0: # received nothing, keep trying
+                continue
+
+            # store in_bytes either as a new line (if no previous line or previous line is incomplete) or as an addition to the previous line
+            if len(responses) == 0:
+                response.append(in_bytes)
+            elif responses[-1] == "\n":
+                responses.append(in_bytes)
+            else:
+                responses[-1] += in_bytes
 
         # evaluate the responses
         response = ''

--- a/plotink/ebb3_serial.py
+++ b/plotink/ebb3_serial.py
@@ -418,7 +418,9 @@ class EBB3:
         n_retry_count = 0
         # poll for response until we get any response and self.port indicates there is no more input, a maximum of self.readline_retry_max times  # TODO adjust/tune retries and timeout params
         while (len(responses) == 0 or self.port.in_waiting > 0) and n_retry_count < self.readline_retry_max:
-            responses.append(self.port.readline())
+            next_line = self.port.readline()
+            if len(next_line) > 0:
+                responses.append(next_line)
             n_retry_count += 1
 
         # evaluate the responses

--- a/plotink/ebb3_serial.py
+++ b/plotink/ebb3_serial.py
@@ -44,6 +44,8 @@ from serial.tools.list_ports import comports \
     #pylint: disable=wrong-import-position, wrong-import-order
 
 
+import logging
+
 class EBB3:
     ''' EBB3: Class for managing EiBotBoard connectivity '''
 
@@ -414,6 +416,7 @@ class EBB3:
         # if the response is unexpected or empty, recursively try again according to `num_tries`
         if not response.startswith(request_name):
             if num_tries > 1:
+                logging.error(f'retrying {type}: {request}')
                 self.retry_count += 1
                 self._send_request(type, request, request_name, num_tries - 1)
             else: # base case; num_tries == 1 (or less but that would be silly)

--- a/plotink/ebb3_serial.py
+++ b/plotink/ebb3_serial.py
@@ -445,6 +445,7 @@ class EBB3:
         if num_tries > 1: # recursive case
             self.retry_count += 1
             logging.error(f'    RETRY {self.retry_count}')
+            self.port.reset_input_buffer() # clear out any inputs from EBB prior to the new request
             response = self._send_request(type, request, request_name, num_tries - 1)
             logging.error(f'    RESPONSE TO RETRY {self.retry_count}: {response}')
             return response

--- a/plotink/ebb3_serial.py
+++ b/plotink/ebb3_serial.py
@@ -418,7 +418,8 @@ class EBB3:
         n_retry_count = 0
         # poll for response until we get any response and self.port indicates there is no more input, a maximum of self.readline_retry_max times  # TODO adjust/tune retries and timeout params
         while (len(responses) == 0 or self.port.in_waiting > 0) and n_retry_count < self.readline_retry_max:
-            responses += self.port.readlines()
+            logging.error(n_retry_count)
+            responses.append(self.port.readline())
             n_retry_count += 1
 
         # evaluate the responses

--- a/plotink/ebb3_serial.py
+++ b/plotink/ebb3_serial.py
@@ -401,7 +401,7 @@ class EBB3:
             # I expect this never to happen based on the pyserial docs. No write timeout is set, so write is blocking.
             logging.error(f'OUT_WAITING == {self.port.out_waiting}')
 
-        self.port.reset_output_buffer() # TODO is this possibly the cause of "expected comma" and "extra param" errors? Am I sure that this fixes the "unkown command" errors?
+        # self.port.reset_output_buffer() # TODO is this possibly the cause of "expected comma" and "extra param" errors? Am I sure that this fixes the "unkown command" errors?
         self.port.write((request + '\r').encode('ascii'))
 
         # and wait for a response

--- a/plotink/ebb3_serial.py
+++ b/plotink/ebb3_serial.py
@@ -416,8 +416,8 @@ class EBB3:
         # and wait for a response
         responses = []
         n_retry_count = 0
-        # poll for response until we run out of retries or self.port indicates there is no more input # TODO adjust/tune retries and timeout params
-        while self.port.in_waiting > 0 and n_retry_count < self.readline_retry_max:
+        # poll for response until we get any response and self.port indicates there is no more input, a maximum of self.readline_retry_max times  # TODO adjust/tune retries and timeout params
+        while (len(responses) == 0 or self.port.in_waiting > 0) and n_retry_count < self.readline_retry_max:
             responses += self.port.readlines()
             n_retry_count += 1
 
@@ -426,6 +426,7 @@ class EBB3:
         if len(responses) == 0:
             raise RuntimeError(f'Timed out with no response after {n_retry_count} tries.')
 
+        logging.error(f'{responses}')
         response = responses[-1].decode('ascii').strip() # we only care about the last response; previous responses are probably related to prior writes and irrelevant here
 
         if not response.startswith(request_name):

--- a/plotink/ebb3_serial.py
+++ b/plotink/ebb3_serial.py
@@ -227,7 +227,7 @@ class EBB3:
 
         verified = False
         try:
-            self.port = serial.Serial(self.port_name, timeout=.1)  # 1 second timeout!
+            self.port = serial.Serial(self.port_name, timeout=.05)  # 1 second timeout!
             self.port.reset_input_buffer() # Requires pyserial 3+.
 
             self.port.write('v\r'.encode('ascii'))    # Request version string.

--- a/plotink/ebb3_serial.py
+++ b/plotink/ebb3_serial.py
@@ -48,6 +48,7 @@ class EBB3:
     ''' EBB3: Class for managing EiBotBoard connectivity '''
 
     MIN_VERSION_STRING = "3.0.2"    # Minimum supported EBB firmware version.
+    readline_retry_max = 25
 
     def __init__(self):
         self.port_name = None       # Port name (enumeration), if any
@@ -310,7 +311,7 @@ class EBB3:
             response = self.port.readline().decode('ascii').strip()
 
             n_retry_count = 0
-            while len(response) == 0 and n_retry_count < 25:
+            while len(response) == 0 and n_retry_count < self.readline_retry_max:
                 # get new response to replace null response if necessary
                 response = self.port.readline().decode('ascii').strip()
                 n_retry_count += 1
@@ -365,7 +366,7 @@ class EBB3:
             response = self.port.readline().decode('ascii').strip()
 
             n_retry_count = 0
-            while len(response) == 0 and n_retry_count < 25:
+            while len(response) == 0 and n_retry_count < self.readline_retry_max:
                 # get new response to replace null response if necessary
                 response = self.port.readline().decode('ascii').strip()
                 n_retry_count += 1
@@ -405,7 +406,12 @@ class EBB3:
         response = ''
         try:
             self.port.write('QG\r'.encode('ascii'))
-            response = self.port.readline().decode('ascii').strip()
+
+            n_retry_count = 0
+            while len(response) == 0 and n_retry_count < self.readline_retry_max:
+                # get new response to replace null response if necessary
+                response = self.port.readline().decode('ascii').strip()
+                n_retry_count += 1
 
             if not response.startswith('QG'):
                 if response:

--- a/plotink/ebb3_serial.py
+++ b/plotink/ebb3_serial.py
@@ -44,8 +44,6 @@ from serial.tools.list_ports import comports \
     #pylint: disable=wrong-import-position, wrong-import-order
 
 
-import logging
-
 class EBB3:
     ''' EBB3: Class for managing EiBotBoard connectivity '''
 
@@ -122,7 +120,6 @@ class EBB3:
         ''' Record error, if it is the first error '''
         if self.err is None:
             self.err = message
-            logging.error(message)
 
 
     def _get_port_name(self, given_name=None):
@@ -432,17 +429,12 @@ class EBB3:
 
         return response
       except RuntimeError as re:
-        logging.error(f'USB ERROR: {re}.\n' +
-                f'    Command: {request}\n    Response: {response}')
         if num_tries > 1: # recursive case
             self.retry_count += 1
-            logging.error(f'    RETRY {self.retry_count}')
             self.port.reset_input_buffer() # clear out any inputs from EBB prior to the new request
             response = self._send_request(type, request, request_name, num_tries - 1)
-            logging.error(f'    RESPONSE TO RETRY {self.retry_count}: {response}')
             return response
         else: # base case
-            logging.error(f'    NOT RETRYING')
             self.record_error('\nEBB Serial Error.' +\
                 f'    Command: {request}\n    Response: {response}')
             return None

--- a/plotink/ebb3_serial.py
+++ b/plotink/ebb3_serial.py
@@ -425,7 +425,6 @@ class EBB3:
         response = ''
         while len(response) == 0 and len(responses) != 0:
             response = responses.pop().decode('ascii').strip() # we only care about the last response; previous responses are probably related to prior writes and irrelevant here
-            logging.error(f'{response}')
 
         if len(response) == 0 and len(responses) == 0:
             raise RuntimeError(f'Timed out with no response (or empty responses) after {n_retry_count} tries.')

--- a/plotink/ebb3_serial.py
+++ b/plotink/ebb3_serial.py
@@ -384,7 +384,7 @@ class EBB3:
         except (TypeError, ValueError):
             return None
 
-    def _send_request(self, type, request, request_name, num_tries = 2):
+    def _send_request(self, type, request, request_name, num_tries = 3):
       '''
         `type` is 'command' or 'query'
         `request` is the command or query to send to the EBB

--- a/plotink/ebb3_serial.py
+++ b/plotink/ebb3_serial.py
@@ -400,7 +400,7 @@ class EBB3:
         `request` is the command or query to send to the EBB
         `request_name` is the short name of `request`
         `num_tries` is the number of times to try if something went wrong. "1" means no retries.
-        return None if there's an error
+        return None if there's an error, otherwise return the response bytestring
       '''
       def response_incomplete(the_response):
             return len(the_response) == 0 or the_response[-1] != "\n"
@@ -424,12 +424,12 @@ class EBB3:
         # evaluate the responses
         response = ''
         if len(responses) == 0:
-            raise RuntimeError('Timed out with no response after {n_retry_count} tries.')
+            raise RuntimeError(f'Timed out with no response after {n_retry_count} tries.')
 
         response = responses[-1].decode('ascii').strip() # we only care about the last response; previous responses are probably related to prior writes and irrelevant here
 
         if not response.startswith(request_name):
-            raise RuntimeError('Received unexpected response after {n_retry_count} tries.')
+            raise RuntimeError(f'Received unexpected response after {n_retry_count} tries.')
         return response
       except RuntimeError as re:
         logging.error(f'USB ERROR: {re}.\n' +
@@ -442,6 +442,8 @@ class EBB3:
             return response
         else: # base case
             logging.error(f'    NOT RETRYING')
+            self.record_error('\nEBB Serial Error.' +\
+                f'    Command: {request}\n    Response: {response}')
             return None
 
 

--- a/plotink/ebb3_serial.py
+++ b/plotink/ebb3_serial.py
@@ -418,7 +418,6 @@ class EBB3:
         n_retry_count = 0
         # poll for response until we get any response and self.port indicates there is no more input, a maximum of self.readline_retry_max times  # TODO adjust/tune retries and timeout params
         while (len(responses) == 0 or self.port.in_waiting > 0) and n_retry_count < self.readline_retry_max:
-            logging.error(n_retry_count)
             responses.append(self.port.readline())
             n_retry_count += 1
 

--- a/plotink/ebb3_serial.py
+++ b/plotink/ebb3_serial.py
@@ -401,9 +401,6 @@ class EBB3:
         `num_tries` is the number of times to try if something went wrong. "1" means no retries.
         return None if there's an error, otherwise return the response bytestring
       '''
-      def response_incomplete(the_response):
-            return len(the_response) == 0 or the_response[-1] != "\n"
-
       old_timeout = self.port.timeout
 
       try:
@@ -417,14 +414,14 @@ class EBB3:
             # I expect this never to happen based on the pyserial docs. No write timeout is set, so write is blocking.
             logging.error(f'OUT_WAITING == {self.port.out_waiting}')
 
-        self.port.reset_output_buffer()
+        self.port.reset_output_buffer() # TODO is this possibly the cause of "expected comma" and "extra param" errors? Am I sure that this fixes the "unkown command" errors?
         self.port.write((request + '\r').encode('ascii'))
 
         # and wait for a response
         responses = []
         n_retry_count = 0
         # poll for response until we get any response and self.port indicates there is no more input, a maximum of readline_retry_max times  # TODO adjust/tune retries and timeout params
-        while (len(responses) == 0 or self.port.in_waiting > 0) and n_retry_count < readline_retry_max:
+        while (len(responses) == 0 or self.port.in_waiting > 0) and n_retry_count < readline_retry_max: # TODO: pull out self.port.in_waiting so if in-waiting never timeout
             in_bytes = self.port.readline()
             n_retry_count += 1
             if len(in_bytes.decode('ascii').strip()) == 0: # received nothing, keep trying
@@ -467,57 +464,13 @@ class EBB3:
       finally:
         self.port.timeout = old_timeout
 
-
-        '''
-        # poll port until we get any kind of response or timeout
-        while len(response) == 0 and n_retry_count < self.readline_retry_max:
-            # get new response to replace null response if necessary
-            response = self.port.readline().decode('ascii')
-            n_retry_count += 1
-
-        if len(response) != 0 and response_incomplete(response): # received a partial response; poll a little longer waiting for the last character to be '\n'
-            n_retry_count = 0
-            while response_incomplete(response) and n_retry_count < self.readline_retry_max:
-                response = response + self.port.readline.decode('ascii')
-                n_retry_count += 1
-
-        if self.port.in_waiting > 0:
-            logging.error('IN_WAITING > 0')
-         '''
          # four possibilities now
          # len(response) == 0, aka a classic timeout
          # len(response) != 0 and response[-1] != "\n", aka a timeout but received some information
          # len(response) != 0 and response[-1] == "\n", aka no timeout
          #        response.startswith(request_name) # yay
          #        not response.startswith(request_name) # boo
-        '''
-        # evaluate the response
-        if not response_incomplete(response) and response.startswith(request_name):
-            # the response is complete, and it is as expected
-            return response.strip()
 
-        # otherwise, recursively try again according to `num_tries`
-        error_type = ""
-        if len(response) == 0:
-            error_type = "Timeout with no response"
-        elif response_incomplete(response):
-            error_type = "Timeout with partial response"
-        else: # aka not response.startswith(request_name)
-            error_type = "Unexpected response"
-
-        response = response.strip()
-        if num_tries > 1: # recursive case
-            self.retry_count += 1
-            logging.error(f'USB ERROR {error_type}: {self.retry_count} retrying {type}: {request} (response was "{response}")')
-            self.port.reset_input_buffer() # Flush input buffer, discarding all its contents. Especially important if port timed out with a partial response
-            response = self._send_request(type, request, request_name, num_tries - 1)
-            logging.error(f'response to retry {self.retry_count} was "{response}"')
-            return response
-        else: # base case
-            self.record_error('\nEBB Serial Error.' +\
-                f'    Command: {request}\n    {error_type}: {response}')
-            return None
-        '''
     def _check_and_record_ebb_error(self, response, type, request):
         '''
         `response` is the response from the EBB, encoded etc.

--- a/plotink/ebb3_serial.py
+++ b/plotink/ebb3_serial.py
@@ -50,7 +50,7 @@ class EBB3:
     ''' EBB3: Class for managing EiBotBoard connectivity '''
 
     MIN_VERSION_STRING = "3.0.2"    # Minimum supported EBB firmware version.
-    readline_retry_max = 40
+    readline_retry_max = 4000000
 
     def __init__(self):
         self.port_name = None       # Port name (enumeration), if any

--- a/plotink/ebb3_serial.py
+++ b/plotink/ebb3_serial.py
@@ -392,11 +392,7 @@ class EBB3:
         `num_tries` is the number of times to try if something went wrong. "1" means no retries.
         return None if there's an error, otherwise return the response bytestring
       '''
-      old_timeout = self.port.timeout
-
       try:
-        # set read timeout to very small so we don't block on waiting for readline to finish
-        self.port.timeout = 1
         readline_retry_max = 25
 
         # send the request
@@ -456,8 +452,6 @@ class EBB3:
             self.record_error('\nEBB Serial Error.' +\
                 f'    Command: {request}\n    Response: {response}')
             return None
-      finally:
-        self.port.timeout = old_timeout
 
     def var_write(self, value, index):
         """

--- a/plotink/ebb3_serial.py
+++ b/plotink/ebb3_serial.py
@@ -423,11 +423,12 @@ class EBB3:
 
         # evaluate the responses
         response = ''
-        if len(responses) == 0:
-            raise RuntimeError(f'Timed out with no response after {n_retry_count} tries.')
+        while len(response) == 0 and len(responses) != 0:
+            response = responses.pop().decode('ascii').strip() # we only care about the last response; previous responses are probably related to prior writes and irrelevant here
+            logging.error(f'{response}')
 
-        logging.error(f'{responses}')
-        response = responses[-1].decode('ascii').strip() # we only care about the last response; previous responses are probably related to prior writes and irrelevant here
+        if len(response) == 0 and len(responses) == 0:
+            raise RuntimeError(f'Timed out with no response (or empty responses) after {n_retry_count} tries.')
 
         if not response.startswith(request_name):
             raise RuntimeError(f'Received unexpected response after {n_retry_count} tries.')

--- a/plotink/ebb3_serial.py
+++ b/plotink/ebb3_serial.py
@@ -410,11 +410,15 @@ class EBB3:
         n_retry_count = 0
         while (len(response) == 0 or response[-1] != "\n") and n_retry_count < self.readline_retry_max:
             # get new response to replace null response if necessary
-            response = response + self.port.readline().decode('ascii').strip()
+            response = response + self.port.readline().decode('ascii')
             n_retry_count += 1
 
         if response[-1] != "\n":
            logging.error(f'readline did not return full line. according to pyserial docs, since the last character of the response is not a newline, there was a timeout and we received a partial response. The response is \"{response}\"')
+        else:
+            logging.error(f'readline returned full line: {response}')
+
+        response = response.strip()
 
         # Special case: Try again _once_ if command has syntax error.
         if '!8 Err' in response:

--- a/plotink/ebb3_serial.py
+++ b/plotink/ebb3_serial.py
@@ -308,14 +308,7 @@ class EBB3:
         response = ''
         try:
             self.port.write((cmd + '\r').encode('ascii'))
-            response = self.port.readline().decode('ascii').strip()
-
-            n_retry_count = 0
-            while len(response) == 0 and n_retry_count < self.readline_retry_max:
-                # get new response to replace null response if necessary
-                response = self.port.readline().decode('ascii').strip()
-                n_retry_count += 1
-
+            response = self._readline_with_retries()
             if not response.startswith(cmd_name):
                 if response:
                     error_msg = '\nUnexpected response from EBB.' +\
@@ -334,7 +327,6 @@ class EBB3:
             self.record_error(error_msg)
 
         return bool(self.err is None) # Return True if no error, False if error.
-
 
     def query(self, qry):
         '''
@@ -363,14 +355,7 @@ class EBB3:
         response = ''
         try:
             self.port.write((qry + '\r').encode('ascii'))
-            response = self.port.readline().decode('ascii').strip()
-
-            n_retry_count = 0
-            while len(response) == 0 and n_retry_count < self.readline_retry_max:
-                # get new response to replace null response if necessary
-                response = self.port.readline().decode('ascii').strip()
-                n_retry_count += 1
-
+            response = self._readline_with_retries()
         except (serial.SerialException, IOError, RuntimeError, OSError):
             if qry_name.lower() not in ["rb", "r", "bl"]: # Ignore err on these commands
                 error_msg = f'USB communication error after query: {qry}'
@@ -406,13 +391,7 @@ class EBB3:
         response = ''
         try:
             self.port.write('QG\r'.encode('ascii'))
-
-            n_retry_count = 0
-            while len(response) == 0 and n_retry_count < self.readline_retry_max:
-                # get new response to replace null response if necessary
-                response = self.port.readline().decode('ascii').strip()
-                n_retry_count += 1
-
+            response = self._readline_with_retries()
             if not response.startswith('QG'):
                 if response:
                     error_msg = '\nUnexpected response from EBB.' +\
@@ -435,6 +414,15 @@ class EBB3:
             return int(response[3:], 16) # Strip off query name ("QG,") and convert to int.
         except (TypeError, ValueError):
             return None
+
+    def _readline_with_retries(self):
+        response = ""
+        n_retry_count = 0
+        while len(response) == 0 and n_retry_count < self.readline_retry_max:
+            # get new response to replace null response if necessary
+            response = self.port.readline().decode('ascii').strip()
+            n_retry_count += 1
+        return response
 
     def var_write(self, value, index):
         """

--- a/plotink/ebb3_serial.py
+++ b/plotink/ebb3_serial.py
@@ -408,9 +408,9 @@ class EBB3:
         # and wait for a response
         response = ""
         n_retry_count = 0
-        while len(response) == 0 and n_retry_count < self.readline_retry_max:
+        while (len(response) == 0 or response[-1] != "\n") and n_retry_count < self.readline_retry_max:
             # get new response to replace null response if necessary
-            response = self.port.readline().decode('ascii').strip()
+            response = response + self.port.readline().decode('ascii').strip()
             n_retry_count += 1
 
         if response[-1] != "\n":

--- a/plotink/ebb3_serial.py
+++ b/plotink/ebb3_serial.py
@@ -412,11 +412,13 @@ class EBB3:
         readline_retry_max = 25
 
         # send the request
-        self.port.write((request + '\r').encode('ascii'))
-
+ 
         if self.port.out_waiting > 0:
             # I expect this never to happen based on the pyserial docs. No write timeout is set, so write is blocking.
             logging.error(f'OUT_WAITING == {self.port.out_waiting}')
+
+        self.port.reset_output_buffer()
+        self.port.write((request + '\r').encode('ascii'))
 
         # and wait for a response
         responses = []


### PR DESCRIPTION
In general the diff looks more dramatic than the changes really are, due to some refactoring I did early on to avoid making the same changes multiple times in different places. The vast majority of the time, no changes to behavior should be noted (other than some error messages being slightly modified).

Summary of changes:
* Retry sending certain commands/queries up to 3 times. Retries are only attempted if re-sending the command will not cause motor position errors (i.e., the EBB sent an error message indicating that the command/query was not understood OR `plotink` timed out waiting for a response from the EBB AND the command/query is idempotent).
* Add a counter for total number of retries in a plot. Not currently reported to the user anywhere.
* Previously the code assumed that serial.Serial.readline always returned a full line. This turns out to have been a faulty assumption, so I fixed that.
* Made the code more robust to getting out-of-sync with the EBB, by reading as much output from the EBB as is available (up to a maximum number of polls).