### PR TITLE
Make `ebb3_serial` more robust

### DIFF
--- a/plotink/ebb3_serial.py
+++ b/plotink/ebb3_serial.py
@@ -48,6 +48,7 @@ class EBB3:
     ''' EBB3: Class for managing EiBotBoard connectivity '''
 
     MIN_VERSION_STRING = "3.0.2"    # Minimum supported EBB firmware version.
+    readline_poll_max = 25
 
     def __init__(self):
         self.port_name = None       # Port name (enumeration), if any
@@ -309,11 +310,11 @@ class EBB3:
             self.port.write((cmd + '\r').encode('ascii'))
             response = self.port.readline().decode('ascii').strip()
 
-            n_retry_count = 0
-            while len(response) == 0 and n_retry_count < 25:
+            n_poll_count = 0
+            while len(response) == 0 and n_poll_count < self.readline_poll_max:
                 # get new response to replace null response if necessary
                 response = self.port.readline().decode('ascii').strip()
-                n_retry_count += 1
+                n_poll_count += 1
 
             if not response.startswith(cmd_name):
                 if response:
@@ -364,11 +365,11 @@ class EBB3:
             self.port.write((qry + '\r').encode('ascii'))
             response = self.port.readline().decode('ascii').strip()
 
-            n_retry_count = 0
-            while len(response) == 0 and n_retry_count < 25:
+            n_poll_count = 0
+            while len(response) == 0 and n_poll_count < self.readline_poll_max:
                 # get new response to replace null response if necessary
                 response = self.port.readline().decode('ascii').strip()
-                n_retry_count += 1
+                n_poll_count += 1
 
         except (serial.SerialException, IOError, RuntimeError, OSError):
             if qry_name.lower() not in ["rb", "r", "bl"]: # Ignore err on these commands
@@ -405,7 +406,12 @@ class EBB3:
         response = ''
         try:
             self.port.write('QG\r'.encode('ascii'))
-            response = self.port.readline().decode('ascii').strip()
+
+            n_poll_count = 0
+            while len(response) == 0 and n_poll_count < self.readline_poll_max:
+                # get new response to replace null response if necessary
+                response = self.port.readline().decode('ascii').strip()
+                n_poll_count += 1
 
             if not response.startswith('QG'):
                 if response:

--- a/plotink/ebb3_serial.py
+++ b/plotink/ebb3_serial.py
@@ -399,32 +399,64 @@ class EBB3:
         `num_tries` is the number of times to try if something went wrong. "1" means no retries.
         return None if there's an error
         '''
+        def response_incomplete(the_response):
+            return len(the_response) == 0 or the_response[-1] != "\n"
+
         # send the request
         self.port.write((request + '\r').encode('ascii'))
 
         # and wait for a response
         response = ""
         n_poll_count = 0
+
+        # poll port until we get any kind of response or timeout
         while len(response) == 0 and n_poll_count < self.readline_poll_max:
             # get new response to replace null response if necessary
             response = self.port.readline().decode('ascii').strip()
             n_poll_count += 1
 
-        # evaluate that response
-        # if the response is unexpected or empty, recursively try again according to `num_tries`
-        if not response.startswith(request_name):
-            if num_tries > 1:
-                self.retry_count += 1
-                self._send_request(type, request, request_name, num_tries - 1)
-            else: # base case; num_tries == 1 (or less but that would be silly)
-                if response:
-                    error_msg = '\nUnexpected response from EBB.' +\
-                       f'    Command: {request}\n    Response: {response}'
-                else:
-                    error_msg = f'EBB Serial Timeout after {type}: {request}'
-                self.record_error(error_msg)
-                return None
-        return response
+        if len(response) != 0 and response_incomplete(response): # received a partial response; poll a little longer waiting for the last character to be '\n'
+            n_poll_count = 0
+            while response_incomplete(response) and n_poll_count < self.readline_poll_max:
+                response = response + self.port.readline.decode('ascii')
+                n_poll_count += 1
+
+        if self.port.in_waiting > 0:
+            logging.error('IN_WAITING > 0')
+
+         # four possibilities now
+         # len(response) == 0, aka a classic timeout
+         # len(response) != 0 and response[-1] != "\n", aka a timeout but received some information
+         # len(response) != 0 and response[-1] == "\n", aka no timeout
+         #        response.startswith(request_name) # yay
+         #        not response.startswith(request_name) # boo
+
+        # evaluate the response
+        if not response_incomplete(response) and response.startswith(request_name):
+            # the response is complete, and it is as expected
+            return response.strip()
+
+        # otherwise, recursively try again according to `num_tries`
+        error_type = ""
+        if len(response) != 0:
+            error_type = "Timeout with no response"
+        elif response_incomplete(response):
+            error_type = "Timeout with partial response"
+        else: # aka not response.startswith(request_name)
+            error_type = "Unexpected response"
+
+        response = response.strip()
+        if num_tries > 1: # recursive case
+            self.retry_count += 1
+            logging.error(f'USB ERROR {error_type}: {self.retry_count} retrying {type}: {request} (response was "{response}")')
+            self.port.reset_input_buffer() # Flush input buffer, discarding all its contents. Especially important if port timed out with a partial response
+            response = self._send_request(type, request, request_name, num_tries - 1)
+            logging.error(f'response to retry {self.retry_count} was "{response}"')
+            return response
+        else: # base case
+            self.record_error('\nEBB Serial Error.' +\
+                f'    Command: {request}\n    {error_type}: {response}')
+            return None
 
     def _check_and_record_ebb_error(self, response, type, request):
         '''

--- a/plotink/ebb3_serial.py
+++ b/plotink/ebb3_serial.py
@@ -356,18 +356,24 @@ class EBB3:
         try:
             self.port.write((qry + '\r').encode('ascii'))
             response = self._readline_with_polls()
+            if not response.startswith(qry_name):
+                if response:
+                    error_msg = '\nUnexpected response from EBB.' +\
+                       f'    Query: {qry}\n    Response: {response}'
+                else:
+                    error_msg = f'EBB Serial Timeout after query: {qry}'
+                self.record_error(error_msg)
+                return None
         except (serial.SerialException, IOError, RuntimeError, OSError):
             if qry_name.lower() not in ["rb", "r", "bl"]: # Ignore err on these commands
                 error_msg = f'USB communication error after query: {qry}'
                 self.record_error(error_msg)
                 return None
 
-        if ('Err:' in response) or (not response.startswith(qry_name)):
-            if response:
-                error_msg = '\nUnexpected response from EBB.' +\
-                   f'    Query: {qry}\n    Response: {response}'
-            else:
-                error_msg = f'EBB Serial Timeout after query: {qry}'
+
+        if 'Err:' in response:
+            error_msg = 'Error reported by EBB.\n' +\
+               f'    Query: {qry}\n    Response: {response}'
             self.record_error(error_msg)
             return None
 

--- a/plotink/ebb3_serial.py
+++ b/plotink/ebb3_serial.py
@@ -321,10 +321,8 @@ class EBB3:
             if cmd_name.lower() not in ["rb", "r", "bl"]: # Ignore err on these commands
                 error_msg = f'USB communication error after command: {cmd}'
                 self.record_error(error_msg)
-        if 'Err:' in response:
-            error_msg = 'Error reported by EBB.\n' +\
-               f'    Command: {cmd}\n    Response: {response}'
-            self.record_error(error_msg)
+
+        self._check_and_record_ebb_error(response, 'Command', cmd)
 
         return bool(self.err is None) # Return True if no error, False if error.
 
@@ -370,11 +368,7 @@ class EBB3:
                 self.record_error(error_msg)
                 return None
 
-
-        if 'Err:' in response:
-            error_msg = 'Error reported by EBB.\n' +\
-               f'    Query: {qry}\n    Response: {response}'
-            self.record_error(error_msg)
+        if self._check_and_record_ebb_error(response, 'Query', qry):
             return None
 
         header_len = len(qry_name)
@@ -411,11 +405,9 @@ class EBB3:
             self.record_error(error_msg)
             return None
 
-        if 'Err:' in response:
-            error_msg = 'Error reported by EBB.\n' +\
-               f'    Query: QG\n    Response: {response}'
-            self.record_error(error_msg)
+        if self._check_and_record_ebb_error(response, 'Query', 'QG'):
             return None
+
         try:
             return int(response[3:], 16) # Strip off query name ("QG,") and convert to int.
         except (TypeError, ValueError):
@@ -429,6 +421,21 @@ class EBB3:
             response = self.port.readline().decode('ascii').strip()
             n_poll_count += 1
         return response
+
+    def _check_and_record_ebb_error(self, response, type, request):
+        '''
+        `response` is the response from the EBB, encoded etc.
+        `type` is "command" or "query"
+        `request` is the previous command or query sent to the EBB
+        returns True if the ebb reported an error, else False
+        '''
+        if 'Err:' in response:
+            formatted_type = type.capitalize()
+            error_msg = 'Error reported by EBB.\n' +\
+               f'    {formatted_type}: {request}\n    Response: {response}'
+            self.record_error(error_msg)
+            return True
+        return False
 
     def var_write(self, value, index):
         """

--- a/plotink/ebb3_serial.py
+++ b/plotink/ebb3_serial.py
@@ -58,7 +58,9 @@ class EBB3:
         self.name = None            # EBB "nickname," if known
         self.err = None             # None, or a string giving first fatal error message.
         self.caller = None          # None, or a string indicating which program opened the port
-
+        self.retry_count = 0        # A counter keeping track of how many times a command or
+                                    # query had to be retried due to timing out or an unexpected
+                                    # response from the EBB
 
     def find_first(self):
         '''
@@ -305,10 +307,8 @@ class EBB3:
         else:
             cmd_name = cmd[0:2]     # All other cases: Command names are two letters long.
 
-        response = ''
         try:
-            self.port.write((cmd + '\r').encode('ascii'))
-            response = self._get_and_eval_response('command', cmd, cmd_name)
+            response = self._send_request('command', cmd, cmd_name)
             if response is None:
                 return False
         except (serial.SerialException, IOError, RuntimeError, OSError):
@@ -344,10 +344,8 @@ class EBB3:
         else:
             qry_name = qry[0:2]     # Cases except QU: Query responses are two letters long.
 
-        response = ''
         try:
-            self.port.write((qry + '\r').encode('ascii'))
-            response = self._get_and_eval_response('query', qry, qry_name)
+            response = self._send_request('query', qry, qry_name)
             if response is None:
                 return None
         except (serial.SerialException, IOError, RuntimeError, OSError):
@@ -376,10 +374,8 @@ class EBB3:
         if (self.port is None) or (self.err is not None):
             return None
 
-        response = ''
         try:
-            self.port.write('QG\r'.encode('ascii'))
-            response = self._get_and_eval_response('query', 'QG', 'QG')
+            response = self._send_request('query', 'QG', 'QG')
             if response is None:
                 return None
         except (serial.SerialException, IOError, RuntimeError, OSError):
@@ -395,12 +391,18 @@ class EBB3:
         except (TypeError, ValueError):
             return None
 
-    def _get_and_eval_response(self, type, request, request_name):
-        '''
-        `request` is the previous command or query ent to the Ebb
+    def _send_request(self, type, request, request_name, num_tries = 3):
+      '''
         `type` is 'command' or 'query'
+        `request` is the command or query to send to the EBB
+        `request_name` is the short name of `request`
+        `num_tries` is the number of times to try if something went wrong. "1" means no retries.
         return None if there's an error
         '''
+        # send the request
+        self.port.write((request + '\r').encode('ascii'))
+
+        # and wait for a response
         response = ""
         n_poll_count = 0
         while len(response) == 0 and n_poll_count < self.readline_poll_max:
@@ -408,14 +410,20 @@ class EBB3:
             response = self.port.readline().decode('ascii').strip()
             n_poll_count += 1
 
+        # evaluate that response
+        # if the response is unexpected or empty, recursively try again according to `num_tries`
         if not response.startswith(request_name):
-            if response:
-                error_msg = '\nUnexpected response from EBB.' +\
-                   f'    Command: {request}\n    Response: {response}'
-            else:
-                error_msg = f'EBB Serial Timeout after {type}: {request}'
-            self.record_error(error_msg)
-            return None
+            if num_tries > 1:
+                self.retry_count += 1
+                self._send_request(type, request, request_name, num_tries - 1)
+            else: # base case; num_tries == 1 (or less but that would be silly)
+                if response:
+                    error_msg = '\nUnexpected response from EBB.' +\
+                       f'    Command: {request}\n    Response: {response}'
+                else:
+                    error_msg = f'EBB Serial Timeout after {type}: {request}'
+                self.record_error(error_msg)
+                return None
         return response
 
     def _check_and_record_ebb_error(self, response, type, request):


### PR DESCRIPTION
In general the diff looks more dramatic than the changes really are, due to some refactoring I did early on to avoid making the same changes multiple times in different places. The vast majority of the time, no changes to behavior should be noted (other than some error messages being slightly modified).

Summary of changes:

Retry sending certain commands/queries up to 3 times. Retries are only attempted if re-sending the command will not cause motor position errors (i.e., the EBB sent an error message indicating that the command/query was not understood OR plotink timed out waiting for a response from the EBB AND the command/query is idempotent).
Add a counter for total number of retries in a plot. Not currently reported to the user anywhere.
Previously the code assumed that serial.Serial.readline always returned a full line. This turns out to have been a faulty assumption, so I fixed that.
Made the code more robust to getting out-of-sync with the EBB, by reading as much output from the EBB as is available (up to a maximum number of polls).