### PR TITLE
Fix bootload not working 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2024 Bantam Tools
+Copyright (c) 2026 Bantam Tools
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/plotink/ebb3_serial.py
+++ b/plotink/ebb3_serial.py
@@ -34,7 +34,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 '''
 
-__version__ = '0.2.2'  # Dated 2026-03-07
+__version__ = '0.2.3'  # Dated 2026-03-08
 
 from packaging.version import parse, InvalidVersion
 

--- a/plotink/ebb3_serial.py
+++ b/plotink/ebb3_serial.py
@@ -108,6 +108,7 @@ class EBB3:
             return False
         try:
             self.port.write('BL\r'.encode('ascii'))
+            self.port.flush()
             self.disconnect()
             return True
         except (serial.SerialException, serial.serialutil.PortNotOpenError):

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='plotink',
-    version='1.14.1',
+    version='1.14.2',
     python_requires='>=3.6.0',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/test/test_ebb3_serial.py
+++ b/test/test_ebb3_serial.py
@@ -508,6 +508,19 @@ class RebootBootloadTestCase(unittest.TestCase):
         self.assertTrue(result)
         self.assertIsNone(ebb.port)
 
+    def test_bootload_flushes_before_close(self):
+        """Verify flush() is called before disconnect() so the BL command
+        is fully transmitted over USB before the port is closed."""
+        ebb = ebb3_serial.EBB3()
+        mock_port = MagicMock()
+        call_order = []
+        mock_port.flush.side_effect = lambda: call_order.append('flush')
+        mock_port.close.side_effect = lambda: call_order.append('close')
+        ebb.port = mock_port
+        result = ebb.bootload()
+        self.assertTrue(result)
+        self.assertEqual(call_order, ['flush', 'close'])
+
     def test_bootload_no_port(self):
         ebb = ebb3_serial.EBB3()
         result = ebb.bootload()


### PR DESCRIPTION
## Summary
- Add `self.port.flush()` before `self.disconnect()` in `bootload()` to ensure the `BL` command is fully transmitted over USB before the port is closed
- Add test verifying flush-before-close ordering

## Root cause
pyserial's `close()` calls `os.close(fd)` without `tcdrain()`. On macOS USB-CDC ports, this can discard buffered output. 

## Test plan
- [x] 77 unit tests pass (76 existing + 1 new)
- [x] Verified fix in Inkscape with hardware: EBB enters bootloader mode after patch
- [x] CLI bootload still works
